### PR TITLE
Fixed initWithDictionary issue in Category.m

### DIFF
--- a/Classes/Models/Category.m
+++ b/Classes/Models/Category.m
@@ -39,7 +39,7 @@
 - (id)initWithDictionary:(NSDictionary *)dictionary {
 	if (self = [super init]) {
 		if (dictionary != nil) {
-			self.identifier = [dictionary objectForKey:@"id"];
+			self.identifier = [dictionary stringForKey:@"id"];
 			self.title = [dictionary objectForKey:@"title"];
 			self.description = [dictionary objectForKey:@"description"];
 			self.color = [UIColor colorFromHexString:[dictionary objectForKey:@"color"]];


### PR DESCRIPTION
The initWithDictionary method in Category.m was using the objectForKey method when populating the Category identifier. This was returning an NSNumber, but we treat the identifier as an NSString, so I changed the initializer to use stringForKey instead to make sure we get back a string.

This was causing a crash in the Mapping the Mangroves application.
