### PR TITLE
Fixed issue with crashing map view when tapping on a pin

### DIFF
--- a/App/Classes/Controllers/USHReportMapViewController.m
+++ b/App/Classes/Controllers/USHReportMapViewController.m
@@ -126,22 +126,19 @@
 	MKPinAnnotationView *annotationView = [MKPinAnnotationView getPinForMap:map andAnnotation:annotation];
     DLog(@"%@", annotation.title);
 	if ([annotation class] != MKUserLocation.class) {
-		UIButton *annotationButton = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
-		[annotationButton addTarget:self action:@selector(annotationClicked:) forControlEvents:UIControlEventTouchUpInside];
-		annotationView.rightCalloutAccessoryView = annotationButton;
+		annotationView.rightCalloutAccessoryView = [UIButton buttonWithType:UIButtonTypeDetailDisclosure];
 	}
 	return annotationView;
 }
 
-- (void) annotationClicked:(UIButton *)button {
-	MKPinAnnotationView *annotationView = (MKPinAnnotationView *)[[button superview] superview];
-	USHMapAnnotation *mapAnnotation = (USHMapAnnotation *)annotationView.annotation;
+- (void)mapView:(MKMapView *)mapView annotationView:(MKAnnotationView *)view calloutAccessoryControlTapped:(UIControl *)control {
+	USHMapAnnotation *mapAnnotation = (USHMapAnnotation *)view.annotation;
 	if ([mapAnnotation class] == MKUserLocation.class) {
-        [UIAlertView showWithTitle:NSLocalizedString(@"User Location", nil) 
-                           message:[NSString stringWithFormat:@"%f,%f", mapAnnotation.coordinate.latitude, mapAnnotation.coordinate.longitude] 
-                          delegate:self 
-                               tag:0 
-                            cancel:NSLocalizedString(@"OK", nil) 
+        [UIAlertView showWithTitle:NSLocalizedString(@"User Location", nil)
+                           message:[NSString stringWithFormat:@"%f,%f", mapAnnotation.coordinate.latitude, mapAnnotation.coordinate.longitude]
+                          delegate:self
+                               tag:0
+                            cancel:NSLocalizedString(@"OK", nil)
                            buttons:nil];
 	}
 	else {


### PR DESCRIPTION
This fixes issue #74.

The problem was that it was relying on the [[button superview] superview] layout hierarchy, which changed in iOS 7. I changed this to use the calloutAccessoryControlTapped instead.

Tested on iOS 6.1 and iOS 7.1.
